### PR TITLE
Switch to crazy-max/ghaction-import-gpg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,10 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
Release workflow failed when I tried to release v4.2.1:
https://github.com/get-bridge/terraform-provider-spinnaker/actions/runs/3651844049

Updating to use this other action as recommened by Hashicorp in this issue:
https://github.com/hashicorp/ghaction-import-gpg/issues/11